### PR TITLE
Update to latest node.js version

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -15,9 +15,9 @@ if (-Not (Test-Path $path_to_node)) {
     # Determine the appropriate binary for the architecture.
     Write-Host -NoNewline "Downloading Node.js runtime... "
     If ($env:processor_architecture -eq "AMD64") {
-        $script:node_url = "http://nodejs.org/dist/v0.10.35/x64/node.exe"
+        $script:node_url = "http://nodejs.org/dist/v0.12.2/x64/node.exe"
     } ElseIf ($env:processor_architecture -eq "x86") {
-        $script:node_url = "http://nodejs.org/dist/v0.10.35/node.exe"
+        $script:node_url = "http://nodejs.org/dist/v0.12.2/node.exe"
     } Else {
         throw "Unsupported architecture found."
     }


### PR DESCRIPTION
This is _completely_ untested, but the URLs don't 404.

I don't have a Windows box, I just need `0.12` for work.
But if it's enough to download latest binaries, this should do it :smile: 
